### PR TITLE
Add multi-CSP auth methods, Organization/Group RBAC, and workspace features

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -62,5 +62,4 @@ jobs:
       - name: Build image
         env:
           IMAGE_NAME: ${{ github.event.repository.name }}
-        #run: docker image build --file ./Dockerfile.mciammanager --tag $IMAGE_NAME .
-        run: docker image build --file ./dockerfiles/mc-iam-manager/Dockerfile.mciammanager --tag $IMAGE_NAME .
+        run: docker image build --file ./Dockerfile.mciammanager --tag $IMAGE_NAME .


### PR DESCRIPTION
## Summary

Sync the `MZC-CSC/mc-iam-manager` `develop` branch into
`m-cmp/mc-iam-manager`, bringing in 140 commits across ~30 merged PRs
(#57 – #92). Highlights:

- Add per-authentication-method (OIDC / SAML / SECRET_KEY) CSP credential
  issuance dispatcher with multi-CSP support (AWS, GCP, Alibaba, Tencent,
  Azure, IBM)
- Add CSP Account, CSP IDP Config, and CSP Validation management APIs
  including IDP summary and bulk health-check
- Add Organization management (self-referencing tree) and Group-based RBAC
  (group ↔ user, platform-role, workspace-role assignments)
- Add Workspace Invitation feature with end-to-end send/accept/reject flow
  and admin approval workflow
- Add Manual Project ↔ Namespace sync APIs (diff preview + selective apply
  per workspace)
- Add Company management API (single-tenant info CRUD)
- Add user self-service endpoints (`/users/me`, password change, effective
  platform/workspace roles, deactivation, withdrawal)
- Fix Keycloak issuer URL for AWS OIDC trust policy in reverse-proxy
  deployments (`MC_IAM_MANAGER_KEYCLOAK_EXTERNAL_URL`)
- Add `tool/swagger-to-actions` to auto-generate `service-actions.yaml`
  from Swagger output, and regenerate Swagger docs
- Update `readme.md` and add Korean `readme_kr.md`
- Fix broken Dockerfile path in CI workflow

## Changes

### CSP Credential Authentication (M4-CSP-032 / 033 / 034 / 035 / 036 / 037)

- Authentication-method dispatcher routes credential issuance by
  `OIDC | SAML | SECRET_KEY` per CSP IDP config
- AWS: fix SAML token exchange for `AssumeRoleWithSAML`; OIDC trust policy
  now uses Keycloak `ExternalURL` (not internal hostname)
- GCP: SAML support via Workload Identity Federation
  (`subjectTokenType` parameter)
- Alibaba: RAM SAML temporary credentials, OIDC via `AssumeRoleWithOIDC`
  with ID-token flow, Timestamp/SignatureNonce added to STS calls
- Azure: OIDC credential issuance
- Tencent: SAML credential issuance
- IBM: OIDC credential issuance
- New `POST /api/workspaces/credentials/validate` validates issued
  credentials end-to-end
- New SAML pre-check gate prevents credential issuance before SAML
  mapper is configured
- New env: `CSP_ROLE_PREFIX`, `SAML_CLIENT_ID_AWS`, `SAML_CLIENT_ID_ALIBABA`

### CSP IAM Role / Account / IDP Management

- `csp_account_handler.go` — 8 endpoints: list / create / get / update /
  delete / validate / activate / deactivate
- `csp_idp_config_handler.go` — 10 endpoints: list / create / get /
  update / delete / test / activate / deactivate / summary /
  bulk-health-check
- `csp_validation_handler.go` — credential validation endpoint
- `csp_iam_handler.go` — direct CSP IAM role management API (IDO-37)
- `IAM-BUG-004` fix: `validateCspAccount` now performs real CSP
  infrastructure validation
- Refactor: AWS IAM logic extracted from repository into
  `AwsCredentialService` interface (testable boundary)
- `listCSPRoles` response type changed from `RoleMaster` to `CspRole`
  and Swagger regenerated

### Keycloak External URL Fix (kc-issuer)

- Add `MC_IAM_MANAGER_KEYCLOAK_EXTERNAL_URL` config field, separating
  internal admin URL from the public OIDC issuer URL
- AWS OIDC trust policies now reference the external (reverse-proxy)
  URL so federated assume-role works in production
- Externalize hardcoded `AWS_ACCOUNT_ID`; rename
  `KEYCLOAK_OIDC_CLIENT_ID` → `MC_IAM_MANAGER_KEYCLOAK_OIDC_CLIENT_ID`
- Add retry logic for CSP role records left in `status="failed"`

### Organization Management (FR-005)

- New `mcmp_organizations` table (self-referencing tree) and
  `mcmp_user_organizations` (M:N)
- Auto-generated codes: top-level `01`–`99`, children append two digits
  (`0101`, `010101`, …)
- PostgreSQL `WITH RECURSIVE` CTE for tree retrieval
- Endpoints: create / list / tree / get-by-id / get-by-code / update /
  delete / users / subtree / move / deletable
- User ↔ org bulk assignment APIs:
  `POST/GET/DELETE /api/users/:userId/organizations`
- `POST /api/setup/initial-organizations` for bootstrap
- `/api/groups/...` aliases route to organization handlers for
  backwards-compatible naming

### Group-Based RBAC (M3-RBAC-023 / 034, IDO-18 / 19 / 20 / 21 / 34)

- New `group_role_handler.go` + `group_role_service.go`
- Group ↔ user assignment (with hierarchy & bulk replace)
- Group ↔ platform-role assignment with available-roles lookup;
  platform-role inheritance through groups
- Group ↔ workspace-role assignment with pre-validation and
  available-workspaces lookup
- `IsRealmRoleAssignedToUser` added to `KeycloakService`
- Bug fixes: `BUG-E4`, `BUG-E6`, idempotent `AssignPlatformRole`
  with Keycloak sync

### Workspace Invitation (IDO-44)

- New `workspace_invitation_handler.go` + service + tests
- User-side: send / list / accept / reject
- Admin-side: list-all / approve / reject-by-admin
- Self endpoints: `/users/me/invitations`,
  `/users/me/invitations/:id/accept|reject`

### User & Self-Service (M2-UG-003 / 004 / 006 / 007 / 030, IDO-23 / 32)

- `GET /api/users/me` — self profile
- `PUT /api/users/me/password` — self password change
- `GET /api/users/me/platform-roles`,
  `GET /api/users/me/workspace-roles` — effective roles
- `PUT /api/users/id/:userId/deactivate|activate` — admin account lifecycle
- `POST /api/users/me/withdrawal`,
  `PUT /api/users/id/:userId/withdraw` — withdrawal flow
- `POST /auth/signup` + signup approval pipeline
- `enabled` filter on `POST /api/users/list` (with nil-guard fix in
  the Keycloak merge loop)
- Organization tree hierarchy on `GET /users/:userId/groups`,
  `PUT` for bulk replace

### Project ↔ Namespace Manual Sync (FR-WS-044)

- `GET /api/setup/projects/sync-diff` — preview missing / unassigned
  projects against `mc-infra-manager` namespaces
- `POST /api/setup/projects/sync` — selectively create / assign
  projects to a chosen workspace (per-`nsId` best-effort, with
  `skipped` / `failed` buckets)
- Existing bulk `POST /api/setup/sync-projects` retained unchanged

### Company Management (M7-COMP-001 ~ 006)

- Single-tenant company info: create / get / update / deactivate / activate

### Menu / Role (FR-007)

- Extend `CreateMenu` with transactional role mapping
- 5 menu-management API bug fixes
- Sync `changeMyPassword` across config and Swagger files

### Tooling

- New `tool/swagger-to-actions/` (Go module) — parses Swagger output
  and emits `service-actions.yaml` with framework metadata
- Regenerated `src/docs/{swagger.json, swagger.yaml, docs.go}` and
  `conf/mc-iam-manager/api.yaml`

### Configuration & Deployment

- `.env_sample`: add `KEYCLOAK_EXTERNAL_URL`, `KEYCLOAK_EXTERNAL_DOMAIN`,
  `CSP_ROLE_PREFIX`, `SAML_CLIENT_ID_AWS`, `SAML_CLIENT_ID_ALIBABA`;
  Keycloak host now includes `/auth` path
- `docker-compose.yaml` / `docker-compose-dev.yaml` updates
- `asset/setup/1_setup_auto.sh` updates

### Documentation

- `readme.md` rewrite: corrected supported CSP list (AWS, GCP, Alibaba,
  Tencent, NCP, NHN, KT, OpenStack), fixed env-var names,
  docker-compose filenames, and `swag init` command
- `readme_kr.md` — new Korean README aligned with the English one

### Tests

- New unit / integration tests: `csp_credential_*`, `csp_validation_*`,
  `csp_account_service`, `csp_idp_config_service`, `company_service`,
  `group_role_service`, `organization_service`,
  `workspace_invitation_service`, `role_service`, `user_service`,
  `list_users_enabled_filter`
- New mocks: `mock_csp_credential_deps`, `mock_keycloak_service`

## Verification

- `go build ./...` passes on `develop`
- `swag init --output ./docs` regenerated and committed
- WS-044 functional tests: 9/9 PASS
- kc-issuer change verified end-to-end against Docker Compose stack

## Notes for reviewers

- The fork has been the active development line; this is a catch-up PR
- New DB tables: `mcmp_organizations`, `mcmp_user_organizations`,
  `mcmp_workspace_invitations`, `mcmp_companies`, CSP IDP / account /
  validation tables
- `MC_IAM_MANAGER_KEYCLOAK_EXTERNAL_URL` is **required** in
  reverse-proxy deployments (falls back to `KEYCLOAK_HOST` with a warning)
- `tool/swagger-to-actions/` is a separate Go module, not compiled into
  the main binary
- Existing PR #76 (`MZC-CSC:feature/csp-account-idp-management`) is fully
  contained in this branch and will auto-close on merge