### PR TITLE
feat(mcmp-api): Add single FrameworkService creation endpoint (POST /api/mcmp-apis)

### DIFF
--- a/src/handler/mcmpapi_handler.go
+++ b/src/handler/mcmpapi_handler.go
@@ -347,6 +347,47 @@ func (h *McmpApiHandler) TestCallGetAllNs(c echo.Context) error {
 	return nil
 }
 
+// CreateFrameworkService godoc
+// @Summary Create MCMP API Service Definition
+// @Description Creates a new MCMP API service (framework) record. Returns 409 if a service with the same name already exists.
+// @Tags McmpAPI
+// @Accept json
+// @Produce json
+// @Param body body model.CreateMcmpApiServiceRequest true "Service definition"
+// @Success 201 {object} mcmpapi.McmpApiService
+// @Failure 400 {object} map[string]string "error: invalid request body or validation failure"
+// @Failure 409 {object} map[string]string "error: framework service already exists"
+// @Failure 500 {object} map[string]string "error: internal server error"
+// @Router /api/mcmp-apis [post]
+// @Id CreateFrameworkService
+// @Security BearerAuth
+func (h *McmpApiHandler) CreateFrameworkService(c echo.Context) error {
+	var req model.CreateMcmpApiServiceRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid body: " + err.Error()})
+	}
+	if err := c.Validate(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	svc := &mcmpapi.McmpApiService{
+		Name:     req.Name,
+		Version:  req.Version,
+		BaseURL:  req.BaseURL,
+		AuthType: req.AuthType,
+		AuthUser: req.AuthUser,
+		AuthPass: req.AuthPass,
+		IsActive: req.IsActive,
+	}
+	if err := h.service.CreateFrameworkService(svc); err != nil {
+		if errors.Is(err, service.ErrFrameworkServiceAlreadyExists) {
+			return c.JSON(http.StatusConflict, map[string]string{"error": err.Error()})
+		}
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusCreated, svc)
+}
+
 // UpdateService godoc
 // @Summary Update MCMP API Service Definition
 // @Description Updates specific fields (e.g., BaseURL, Auth info) of an MCMP API service definition identified by its name. Cannot update name or version.

--- a/src/main.go
+++ b/src/main.go
@@ -443,6 +443,7 @@ func main() {
 		mcmpApis.PUT("/name/:serviceName/versions/:version/activate", mcmpApiHandler.SetActiveVersion, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.POST("/call", mcmpApiHandler.McmpApiCall, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.GET("/test/mc-infra-manager/getallns", mcmpApiHandler.TestCallGetAllNs, middleware.PlatformRoleMiddleware(middleware.Manage))
+		mcmpApis.POST("", mcmpApiHandler.CreateFrameworkService, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.PUT("/name/:serviceName", mcmpApiHandler.UpdateFrameworkService, middleware.PlatformRoleMiddleware(middleware.Manage))
 		mcmpApis.POST("/import", mcmpApiHandler.ImportAPIs, middleware.PlatformRoleMiddleware(middleware.Manage))
 	}

--- a/src/model/request.go
+++ b/src/model/request.go
@@ -266,6 +266,17 @@ type ImportApiResponse struct {
 	FrameworkResults []ImportApiFrameworkResult `json:"frameworkResults"` // Detailed results for each framework
 }
 
+// CreateMcmpApiServiceRequest represents the request body for POST /api/mcmp-apis
+type CreateMcmpApiServiceRequest struct {
+	Name     string `json:"name"     validate:"required,max=100"`
+	Version  string `json:"version"  validate:"required,max=50"`
+	BaseURL  string `json:"baseUrl"  validate:"required,url"`
+	AuthType string `json:"authType,omitempty" validate:"omitempty,oneof=none basic bearer"`
+	AuthUser string `json:"authUser,omitempty"`
+	AuthPass string `json:"authPass,omitempty"`
+	IsActive bool   `json:"isActive,omitempty"`
+}
+
 // SignupRequest represents the signup form data
 type SignupRequest struct {
 	Email        string `json:"email" validate:"required,email"`

--- a/src/service/mcmpapi_service.go
+++ b/src/service/mcmpapi_service.go
@@ -27,6 +27,8 @@ import (
 // Local path to service-actions.yaml file (relative to working directory)
 const localServiceActionsPath = "asset/mcmpapi/service-actions.yaml"
 
+var ErrFrameworkServiceAlreadyExists = errors.New("framework service already exists")
+
 // McmpApiService defines the interface for mcmp API operations
 type McmpApiService interface {
 	GetDB() *gorm.DB
@@ -36,6 +38,7 @@ type McmpApiService interface {
 	SetActiveVersion(serviceName, version string) error
 	GetAllAPIDefinitions(serviceNameFilter, actionNameFilter string) (*mcmpapi.McmpApiDefinitions, error)
 	UpdateService(serviceName string, updates map[string]interface{}) error
+	CreateFrameworkService(svc *mcmpapi.McmpApiService) error
 	McmpApiCall(ctx context.Context, req *model.McmpApiCallRequest) (int, []byte, string, string, error)
 	SyncMcmpAPIsFromYAML() error
 	ImportAPIs(req *model.ImportApiRequest) (*model.ImportApiResponse, error)
@@ -304,6 +307,29 @@ func (s *mcmpApiService) UpdateService(serviceName string, updates map[string]in
 	// }
 
 	return s.repo.UpdateService(serviceName, updates)
+}
+
+// CreateFrameworkService creates a single McmpApiService record within its own transaction.
+func (s *mcmpApiService) CreateFrameworkService(svc *mcmpapi.McmpApiService) error {
+	if err := s.ensureTables(); err != nil {
+		return err
+	}
+	tx := s.db.Begin()
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
+	if err := s.repo.CreateService(tx, svc); err != nil {
+		tx.Rollback()
+		if errors.Is(err, gorm.ErrDuplicatedKey) ||
+			strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+			return ErrFrameworkServiceAlreadyExists
+		}
+		return err
+	}
+	return tx.Commit().Error
 }
 
 // McmpApiCall executes a call to an external MCMP API based on stored definitions and provided parameters. (Renamed)


### PR DESCRIPTION
## Overview

Adds a dedicated REST endpoint for creating a single `McmpApiService` (FrameworkService) record.

Previously, a new framework service could only be registered via the bulk import endpoint (`POST /api/mcmp-apis/import`) which requires an OpenAPI spec URL and processes an array of frameworks. This adds a lightweight alternative for cases where the service metadata is already known and only a single record needs to be registered.

## Changes

| File | Description |
|---|---|
| `src/model/request.go` | Add `CreateMcmpApiServiceRequest` DTO with validation tags |
| `src/service/mcmpapi_service.go` | Add `ErrFrameworkServiceAlreadyExists` sentinel error, `CreateFrameworkService` interface method, and its transaction-owning implementation |
| `src/handler/mcmpapi_handler.go` | Add `CreateFrameworkService` handler with Swagger annotations (`@Id CreateFrameworkService`) |
| `src/main.go` | Register `POST /api/mcmp-apis` route with Manage role middleware |

**No changes to the repository layer** — reuses the existing `repo.CreateService(tx, *McmpApiService)`.

## API

```
POST /api/mcmp-apis
Authorization: Bearer <token>
Content-Type: application/json

{
  "name": "mc-cost-optimizer-fe",   // required, unique PK (max 100 chars)
  "version": "v1",                  // required (max 50 chars)
  "baseUrl": "http://host:7780",    // required, valid URL
  "authType": "none",               // optional: none | basic | bearer
  "authUser": "",                   // optional
  "authPass": "",                   // optional
  "isActive": true                  // optional, default false
}
```

| Status | Condition |
|---|---|
| `201 Created` | Service created successfully; returns the persisted object |
| `400 Bad Request` | Missing required fields or failed validation |
| `409 Conflict` | A service with the same `name` already exists |
| `403 Forbidden` | Insufficient role (requires Manage) |
| `500 Internal Server Error` | Unexpected server error |

## Design Decisions

- **New DTO instead of reusing `ImportApiFramework`**: `ImportApiFramework` carries parser-specific fields (`sourceType`, `sourceUrl`, `repository`) that are irrelevant for direct registration. A narrower DTO improves clarity and Swagger documentation.
- **Transaction owned by the service layer**: Consistent with the existing `ImportAPIs` and `syncFrameworkToDatabase` patterns where the service begins and commits the transaction, keeping the handler free of DB concerns.
- **No pre-existence check**: A pre-check before insert introduces a race condition. Instead, the unique constraint violation from PostgreSQL is caught and mapped to `409 Conflict`.
- **Action/Meta not included**: Single responsibility — this endpoint only creates the service record. Actions can be managed separately via existing endpoints.

## Testing

- [x] `POST /api/mcmp-apis` with valid payload → `201 Created`, object returned
- [x] Duplicate `name` → `409 Conflict`
- [x] Build passes: `go build ./...`
- [ ] Missing required field → `400 Bad Request`
- [ ] Insufficient role token → `403 Forbidden`