### PR TITLE
feat: add menu resource fields to mcmp_menus schema

### DIFF
--- a/asset/menu/menu.yaml
+++ b/asset/menu/menu.yaml
@@ -308,6 +308,9 @@ menus:
     parentid: manage
     displayname: Workflows
     restype: menu
+    viewtype: iframe
+    frameworkservice: mc-workflow-manager-fe
+    path: /web/workflow/list
     isaction: true
     priority: 2
     menunumber: 1998
@@ -316,6 +319,9 @@ menus:
     parentid: manage
     displayname: SW Catalogs
     restype: menu
+    viewtype: iframe
+    frameworkservice: mc-application-manager-fe
+    path: /web/softwareCatalog
     isaction: true
     priority: 2
     menunumber: 1998
@@ -324,6 +330,9 @@ menus:
     parentid: manage
     displayname: Data Migrations
     restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /
     isaction: true
     priority: 2
     menunumber: 1998
@@ -364,6 +373,9 @@ menus:
     parentid: monitorings
     displayname: Monitoring Config
     restype: menu
+    viewtype: local
+    frameworkservice: mc-web-console-front
+    path: /operations/analytics/monitorings/monitoringconfig
     isaction: true
     priority: 2
     menunumber: 1940
@@ -420,6 +432,20 @@ menus:
     parentid: analytics
     displayname: Cost Analysis
     restype: menu
+    viewtype: iframe
+    frameworkservice: mc-cost-optimizer-fe
+    path: /
     isaction: true
     priority: 2
     menunumber: 1998
+
+  - id: observability
+    parentid: analytics
+    displayname: Monitorings
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-observability-fe
+    path: /
+    isaction: true
+    priority: 3
+    menunumber: 1999

--- a/conf/mc-iam-manager/menu.yaml
+++ b/conf/mc-iam-manager/menu.yaml
@@ -348,6 +348,9 @@ menus:
     parentid: manage
     displayname: Workflows
     restype: menu
+    viewtype: iframe
+    frameworkservice: mc-workflow-manager-fe
+    path: /web/workflow/list
     isaction: true
     priority: 2
     menunumber: 1998
@@ -356,6 +359,9 @@ menus:
     parentid: manage
     displayname: SW Catalogs
     restype: menu
+    viewtype: iframe
+    frameworkservice: mc-application-manager-fe
+    path: /web/softwareCatalog
     isaction: true
     priority: 2
     menunumber: 1998
@@ -364,6 +370,9 @@ menus:
     parentid: manage
     displayname: Data Migrations
     restype: menu
+    viewtype: iframe
+    frameworkservice: mc-data-manager-fe
+    path: /
     isaction: true
     priority: 2
     menunumber: 1998
@@ -404,6 +413,9 @@ menus:
     parentid: monitorings
     displayname: Monitoring Config
     restype: menu
+    viewtype: local
+    frameworkservice: mc-web-console-front
+    path: /operations/analytics/monitorings/monitoringconfig
     isaction: true
     priority: 2
     menunumber: 1940
@@ -460,6 +472,20 @@ menus:
     parentid: analytics
     displayname: Cost Analysis
     restype: menu
+    viewtype: iframe
+    frameworkservice: mc-cost-optimizer-fe
+    path: /
     isaction: true
     priority: 2
     menunumber: 1998
+
+  - id: observability
+    parentid: analytics
+    displayname: Monitorings
+    restype: menu
+    viewtype: iframe
+    frameworkservice: mc-observability-fe
+    path: /
+    isaction: true
+    priority: 3
+    menunumber: 1999

--- a/scripts/migration/20260713_mcmp_menus_menu_resource.sql
+++ b/scripts/migration/20260713_mcmp_menus_menu_resource.sql
@@ -1,0 +1,15 @@
+-- IAM-FIX-001: mcmp_menus menu resource columns
+-- See ST3_개발/MIGRATION-GUIDE-mcmp-menus-menu-resource.md
+
+BEGIN;
+
+ALTER TABLE mcmp_menus
+  ADD COLUMN IF NOT EXISTS view_type VARCHAR(20) NOT NULL DEFAULT 'local',
+  ADD COLUMN IF NOT EXISTS framework_service VARCHAR(100) NOT NULL DEFAULT 'mc-web-console-front',
+  ADD COLUMN IF NOT EXISTS path VARCHAR(500) NOT NULL DEFAULT '';
+
+COMMENT ON COLUMN mcmp_menus.view_type IS 'local | iframe | popup';
+COMMENT ON COLUMN mcmp_menus.framework_service IS 'getapihosts service key';
+COMMENT ON COLUMN mcmp_menus.path IS 'path within framework';
+
+COMMIT;

--- a/src/handler/menu_handler.go
+++ b/src/handler/menu_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"io" // Ensure io package is imported
 	"net/http"
@@ -383,6 +384,11 @@ func (h *MenuHandler) CreateMenu(c echo.Context) error {
 	if err != nil {
 		c.Logger().Debugf("CreateMenu err %v", err)
 		errMsg := err.Error()
+		if errors.Is(err, service.ErrInvalidViewType) ||
+			errors.Is(err, service.ErrFrameworkServiceRequired) ||
+			errors.Is(err, service.ErrPathTooLong) {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": errMsg})
+		}
 		if len(errMsg) >= len("존재하지 않는 역할") && errMsg[:len("존재하지 않는 역할")] == "존재하지 않는 역할" {
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": errMsg})
 		}
@@ -452,6 +458,15 @@ func (h *MenuHandler) UpdateMenu(c echo.Context) error {
 		}
 		updates["menu_number"] = menuNumberInt
 	}
+	if menu.ViewType != "" {
+		updates["view_type"] = menu.ViewType
+	}
+	if menu.FrameworkService != "" {
+		updates["framework_service"] = menu.FrameworkService
+	}
+	if menu.Path != "" {
+		updates["path"] = menu.Path
+	}
 
 	if len(updates) == 0 {
 		return c.JSON(http.StatusBadRequest, map[string]string{
@@ -461,8 +476,13 @@ func (h *MenuHandler) UpdateMenu(c echo.Context) error {
 
 	// Call the service method with id and the map of updates
 	if err := h.menuService.Update(id, updates); err != nil {
+		if errors.Is(err, service.ErrInvalidViewType) ||
+			errors.Is(err, service.ErrFrameworkServiceRequired) ||
+			errors.Is(err, service.ErrPathTooLong) {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+		}
 		// Handle specific errors like "not found" if needed
-		if err.Error() == "menu not found" { // Assuming service/repo returns this specific error string
+		if err == repository.ErrMenuNotFound || err.Error() == "menu not found" {
 			return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
 		}
 		return c.JSON(http.StatusInternalServerError, map[string]string{

--- a/src/model/menu.go
+++ b/src/model/menu.go
@@ -13,6 +13,9 @@ type Menu struct {
 	IsAction    bool      `json:"isAction" yaml:"isaction" gorm:"column:is_action;default:false"`
 	Priority    uint      `json:"priority" yaml:"priority" gorm:"column:priority;not null"`
 	MenuNumber  uint      `json:"menuNumber" yaml:"menunumber" gorm:"column:menu_number;not null"`
+	ViewType         string `json:"viewType" yaml:"viewtype" gorm:"column:view_type;not null;default:local"`
+	FrameworkService string `json:"frameworkService" yaml:"frameworkservice" gorm:"column:framework_service;not null;default:mc-web-console-front"`
+	Path             string `json:"path" yaml:"path" gorm:"column:path;not null;default:''"`
 	CreatedAt   time.Time `json:"-" yaml:"-" gorm:"column:created_at;autoCreateTime"` // GORM이 자동 처리
 	UpdatedAt   time.Time `json:"-" yaml:"-" gorm:"column:updated_at;autoUpdateTime"` // GORM이 자동 처리
 }

--- a/src/model/request.go
+++ b/src/model/request.go
@@ -125,6 +125,9 @@ type CreateMenuRequest struct {
 	IsAction    *bool  `json:"isAction"`
 	Priority    string `json:"priority"`
 	MenuNumber  string `json:"menuNumber"`
+	ViewType         string `json:"viewType,omitempty"`
+	FrameworkService string `json:"frameworkService,omitempty"`
+	Path             string `json:"path,omitempty"`
 	RoleIDs     []uint `json:"roleIds,omitempty"` // 생성과 동시에 매핑할 역할 ID 목록 (platform_admin은 항상 자동 매핑)
 }
 type CreateMenuRequests struct {

--- a/src/repository/menu_repository.go
+++ b/src/repository/menu_repository.go
@@ -107,6 +107,9 @@ func (r *MenuRepository) CreateMenu(req *model.CreateMenuRequest) error {
 		IsAction:    isAction,
 		Priority:    priorityInt,
 		MenuNumber:  menuNumberInt,
+		ViewType:         req.ViewType,
+		FrameworkService: req.FrameworkService,
+		Path:             req.Path,
 	}
 	return r.db.Create(menu).Error
 }
@@ -226,7 +229,10 @@ func (r *MenuRepository) UpsertMenus(menus []model.Menu) error {
 	// 모든 컬럼에 대해 충돌 시 업데이트 (ID 기준)
 	if err := tx.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "id"}},
-		DoUpdates: clause.AssignmentColumns([]string{"parent_id", "display_name", "res_type", "is_action", "priority", "menu_number"}),
+		DoUpdates: clause.AssignmentColumns([]string{
+			"parent_id", "display_name", "res_type", "is_action", "priority", "menu_number",
+			"view_type", "framework_service", "path",
+		}),
 	}).Create(&menus).Error; err != nil {
 		tx.Rollback() // 롤백
 		tx.Rollback() // 롤백

--- a/src/service/menu_service.go
+++ b/src/service/menu_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context" // Added
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +21,64 @@ import (
 	"gopkg.in/yaml.v3"
 	"gorm.io/gorm" // Import gorm
 )
+
+const (
+	defaultMenuViewType         = "local"
+	defaultMenuFrameworkService = "mc-web-console-front"
+	maxMenuPathLength           = 500
+)
+
+var (
+	ErrInvalidViewType            = errors.New("invalid viewType")
+	ErrFrameworkServiceRequired   = errors.New("frameworkService required")
+	ErrPathTooLong                = errors.New("path too long")
+)
+
+func normalizeMenuResource(viewType, frameworkService, path string) (string, string, string) {
+	if viewType == "" {
+		viewType = defaultMenuViewType
+	}
+	if frameworkService == "" {
+		frameworkService = defaultMenuFrameworkService
+	}
+	return viewType, frameworkService, path
+}
+
+func validateMenuResource(viewType, frameworkService, path string) error {
+	switch viewType {
+	case "local", "iframe", "popup":
+	default:
+		return ErrInvalidViewType
+	}
+	if (viewType == "iframe" || viewType == "popup") && frameworkService == "" {
+		return ErrFrameworkServiceRequired
+	}
+	if len(path) > maxMenuPathLength {
+		return ErrPathTooLong
+	}
+	return nil
+}
+
+func normalizeAndValidateMenuResource(viewType, frameworkService, path string) (string, string, string, error) {
+	viewType, frameworkService, path = normalizeMenuResource(viewType, frameworkService, path)
+	if err := validateMenuResource(viewType, frameworkService, path); err != nil {
+		return "", "", "", err
+	}
+	return viewType, frameworkService, path, nil
+}
+
+func applyMenuResourceDefaults(menu *model.Menu) error {
+	viewType, frameworkService, path, err := normalizeAndValidateMenuResource(
+		menu.ViewType, menu.FrameworkService, menu.Path,
+	)
+	if err != nil {
+		return err
+	}
+	menu.ViewType = viewType
+	menu.FrameworkService = frameworkService
+	menu.Path = path
+	return nil
+}
 
 // MenuService 메뉴 관련 비즈니스 로직
 type MenuService struct {
@@ -277,7 +336,15 @@ func (s *MenuService) GetMenuByID(id *string) (*model.Menu, error) {
 
 // Create 새 메뉴 생성
 func (s *MenuService) Create(req *model.CreateMenuRequest) error {
-	// TODO: 필요한 비즈니스 로직 추가 (예: 유효성 검사)
+	viewType, frameworkService, path, err := normalizeAndValidateMenuResource(
+		req.ViewType, req.FrameworkService, req.Path,
+	)
+	if err != nil {
+		return err
+	}
+	req.ViewType = viewType
+	req.FrameworkService = frameworkService
+	req.Path = path
 	return s.menuRepo.CreateMenu(req)
 }
 
@@ -339,6 +406,12 @@ func (s *MenuService) CreateWithRoleMappings(req *model.CreateMenuRequest) (*mod
 		IsAction:    isAction,
 		Priority:    priorityInt,
 		MenuNumber:  menuNumberInt,
+		ViewType:         req.ViewType,
+		FrameworkService: req.FrameworkService,
+		Path:             req.Path,
+	}
+	if err := applyMenuResourceDefaults(menu); err != nil {
+		return nil, err
 	}
 
 	// 6. 트랜잭션: 메뉴 생성 + 역할 매핑
@@ -355,13 +428,39 @@ func (s *MenuService) CreateWithRoleMappings(req *model.CreateMenuRequest) (*mod
 
 // Update 메뉴 정보 부분 업데이트
 func (s *MenuService) Update(id string, updates map[string]interface{}) error {
-	// TODO: 필요한 비즈니스 로직 추가 (예: 유효성 검사, 업데이트 가능 필드 제한 등)
-
-	// 업데이트 전 레코드 존재 여부 확인 (선택 사항, Repository에서도 확인)
-	// _, err := s.GetByID(id)
-	// if err != nil {
-	// 	 return err
-	// }
+	_, hasViewType := updates["view_type"]
+	_, hasFramework := updates["framework_service"]
+	_, hasPath := updates["path"]
+	if hasViewType || hasFramework || hasPath {
+		existing, err := s.menuRepo.FindMenuByID(&id)
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			return repository.ErrMenuNotFound
+		}
+		viewType := existing.ViewType
+		frameworkService := existing.FrameworkService
+		path := existing.Path
+		if v, ok := updates["view_type"].(string); ok {
+			viewType = v
+		}
+		if v, ok := updates["framework_service"].(string); ok {
+			frameworkService = v
+		}
+		if v, ok := updates["path"].(string); ok {
+			path = v
+		}
+		viewType, frameworkService, path, err = normalizeAndValidateMenuResource(
+			viewType, frameworkService, path,
+		)
+		if err != nil {
+			return err
+		}
+		updates["view_type"] = viewType
+		updates["framework_service"] = frameworkService
+		updates["path"] = path
+	}
 
 	return s.menuRepo.UpdateMenu(id, updates)
 }
@@ -454,12 +553,19 @@ func (s *MenuService) LoadAndRegisterMenusFromYAML(filePath string) error {
 	for _, menu := range menus {
 		if menu.ID == "home" {
 			// home 메뉴가 있으면 업데이트
+			homeMenu := menu
+			if err := applyMenuResourceDefaults(&homeMenu); err != nil {
+				return fmt.Errorf("invalid home menu resource: %w", err)
+			}
 			if err := s.menuRepo.UpdateMenu("home", map[string]interface{}{
-				"display_name": menu.DisplayName,
-				"res_type":     menu.ResType,
-				"is_action":    menu.IsAction,
-				"priority":     menu.Priority,
-				"menu_number":  menu.MenuNumber,
+				"display_name":      homeMenu.DisplayName,
+				"res_type":          homeMenu.ResType,
+				"is_action":         homeMenu.IsAction,
+				"priority":          homeMenu.Priority,
+				"menu_number":       homeMenu.MenuNumber,
+				"view_type":         homeMenu.ViewType,
+				"framework_service": homeMenu.FrameworkService,
+				"path":              homeMenu.Path,
 			}); err != nil {
 				fmt.Printf("Warning: Failed to update home menu: %v\n", err)
 			}
@@ -483,9 +589,14 @@ func (s *MenuService) LoadAndRegisterMenusFromYAML(filePath string) error {
 	// 4. DB에 Upsert (home 메뉴 제외)
 	var menusToUpsert []model.Menu
 	for _, menu := range menus {
-		if menu.ID != "home" {
-			menusToUpsert = append(menusToUpsert, menu)
+		if menu.ID == "home" {
+			continue
 		}
+		menuCopy := menu
+		if err := applyMenuResourceDefaults(&menuCopy); err != nil {
+			return fmt.Errorf("invalid menu resource for %s: %w", menu.ID, err)
+		}
+		menusToUpsert = append(menusToUpsert, menuCopy)
 	}
 
 	if len(menusToUpsert) > 0 {
@@ -513,6 +624,12 @@ func (s *MenuService) RegisterMenusFromContent(yamlContent []byte) error {
 	if len(menus) == 0 {
 		// log.Printf("No menus found in YAML content, skipping registration.")
 		return nil // 처리할 메뉴 없음
+	}
+
+	for i := range menus {
+		if err := applyMenuResourceDefaults(&menus[i]); err != nil {
+			return fmt.Errorf("invalid menu resource for %s: %w", menus[i].ID, err)
+		}
 	}
 
 	// 2. DB에 Upsert

--- a/src/service/menu_service_resource_test.go
+++ b/src/service/menu_service_resource_test.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"testing"
+)
+
+func TestNormalizeAndValidateMenuResourceDefaults(t *testing.T) {
+	viewType, frameworkService, path, err := normalizeAndValidateMenuResource("", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if viewType != defaultMenuViewType {
+		t.Fatalf("viewType = %q, want %q", viewType, defaultMenuViewType)
+	}
+	if frameworkService != defaultMenuFrameworkService {
+		t.Fatalf("frameworkService = %q, want %q", frameworkService, defaultMenuFrameworkService)
+	}
+	if path != "" {
+		t.Fatalf("path = %q, want empty", path)
+	}
+}
+
+func TestValidateMenuResourceIframeRequiresFramework(t *testing.T) {
+	_, _, _, err := normalizeAndValidateMenuResource("iframe", "", "/")
+	if err != ErrFrameworkServiceRequired {
+		t.Fatalf("err = %v, want %v", err, ErrFrameworkServiceRequired)
+	}
+}
+
+func TestValidateMenuResourceInvalidViewType(t *testing.T) {
+	_, _, _, err := normalizeAndValidateMenuResource("external", "mc-web-console-front", "")
+	if err != ErrInvalidViewType {
+		t.Fatalf("err = %v, want %v", err, ErrInvalidViewType)
+	}
+}
+
+func TestValidateMenuResourcePathTooLong(t *testing.T) {
+	longPath := make([]byte, maxMenuPathLength+1)
+	for i := range longPath {
+		longPath[i] = 'a'
+	}
+	_, _, _, err := normalizeAndValidateMenuResource("local", "mc-web-console-front", string(longPath))
+	if err != ErrPathTooLong {
+		t.Fatalf("err = %v, want %v", err, ErrPathTooLong)
+	}
+}


### PR DESCRIPTION
## Summary
- Add menu resource fields to the mcmp_menus schema (migration, model, request/response)
- Update menu handler, repository, and service logic to support the new menu resource fields
- Update menu.yaml
- Add related unit test for menu service resource handling
