### PR TITLE
fix: Dockerfile .env COPY failure blocking v0.6.2 image build

### DIFF
--- a/Dockerfile.mciammanager
+++ b/Dockerfile.mciammanager
@@ -36,13 +36,15 @@ COPY --from=builder /mc-iam-manager /app/mc-iam-manager
 # Copy necessary assets from the builder stage
 COPY --from=builder /app/asset ./asset
 
-# Copy .env file to multiple locations for compatibility with the application's .env loading logic
-COPY .env /app/.env
-COPY .env /.env
+# .env is no longer tracked in git (IAM-BUG-009), so it doesn't exist in the build
+# context. Ship the template as a fallback default in both lookup paths; godotenv
+# only fills in variables not already set, so real values injected via
+# docker-compose env_file/environment always take precedence over this fallback.
+COPY .env.setup /app/.env
+COPY .env.setup /.env
 
 # Expose the application port (adjust if different)
 EXPOSE 8082
 
 # Command to run the application
-# The application reads .env from multiple locations for compatibility
 CMD ["./mc-iam-manager"]


### PR DESCRIPTION
## Summary

### Fixed
* **v0.6.2 CD pipeline failure**: `Dockerfile.mciammanager`'s runtime stage had `COPY .env /app/.env` / `COPY .env /.env`, baking the build context's `.env` into the image. #152 (IAM-BUG-009, included in v0.6.2) untracked `.env` from git, so CI's checkout no longer has a `.env` file and the image build failed with `"/.env": not found` on every push to `main` and the `v0.6.2` tag — a direct regression from the security fix.

  Fix: COPY the template `.env.setup` (still tracked in git) to both paths instead. This is safe because `godotenv.Load()` (used by `LoadEnvFiles()`) never overrides an already-set OS environment variable — confirmed in `joho/godotenv` v1.5.1's `loadFile`: `if !currentEnv[key] || overload { ... }`, and `Load()` calls it with `overload=false`. Real values injected via docker-compose `env_file`/`environment` always take precedence; the baked-in template only fills gaps.

  Verified locally: `docker build -f Dockerfile.mciammanager --target prod .` succeeds, and `/app/.env`/`/.env` exist inside the built image.

## Note

Releases up to v0.6.1 had `.env` tracked in git, so their image builds would have succeeded with the original `COPY .env ...` — meaning any real secrets in that `.env` at build time may have been baked into image layers pushed to the public `cloudbaristaorg/mc-iam-manager` Docker Hub repo. That's a separate concern from this build fix and needs its own investigation/rotation, out of scope here.

## Migration Notes

* No new required env vars. `v0.6.2`'s Docker image build was broken before this fix — once merged, the `v0.6.2` tag's CD run can be re-triggered (or a new patch tag cut) to actually publish the image.